### PR TITLE
Support JSON-RPC signaling and protocol 975

### DIFF
--- a/src/nethernet/server.ts
+++ b/src/nethernet/server.ts
@@ -6,6 +6,14 @@ import { SignalStructure, SignalType } from '../signaling/struct'
 
 const debugFn = require('debug')('bedrock-portal-nethernet')
 
+type PendingCandidate = {
+  signal: SignalStructure
+  attempts: number
+}
+
+const MAX_PENDING_CANDIDATE_ATTEMPTS = 50
+const PENDING_CANDIDATE_RETRY_MS = 100
+
 const getRandomUint64 = () => {
   const high = Math.floor(Math.random() * 0xFFFFFFFF)
   const low = Math.floor(Math.random() * 0xFFFFFFFF)
@@ -23,6 +31,12 @@ export class Server {
 
   connections: Map<bigint, Connection>
 
+  pendingCandidates: Map<bigint, PendingCandidate[]>
+
+  remoteDescriptionReady: Set<bigint>
+
+  pendingCandidateTimers: Map<bigint, NodeJS.Timeout>
+
   onOpenConnection: (conn: Connection) => void
 
   onCloseConnection: (id: bigint, reason: string) => void
@@ -39,6 +53,12 @@ export class Server {
 
     this.connections = new Map()
 
+    this.pendingCandidates = new Map()
+
+    this.remoteDescriptionReady = new Set()
+
+    this.pendingCandidateTimers = new Map()
+
     this.onOpenConnection = () => { }
 
     this.onCloseConnection = () => { }
@@ -50,13 +70,80 @@ export class Server {
   async handleCandidate(signal: SignalStructure) {
     const conn = this.connections.get(signal.connectionId)
 
-    if (conn) {
-      conn.rtcConnection.addRemoteCandidate(signal.data, '0')
-    }
-    else {
-      debugFn('Received candidate for unknown connection', signal)
+    if (!conn || !this.remoteDescriptionReady.has(signal.connectionId)) {
+      this.queueCandidate(signal)
+      return
     }
 
+    try {
+      conn.rtcConnection.addRemoteCandidate(signal.data, '0')
+    }
+    catch (error) {
+      this.queueCandidate(signal, formatCandidateError(error))
+    }
+  }
+
+  queueCandidate(signal: SignalStructure, reason = 'connection is not ready') {
+    const candidates = this.pendingCandidates.get(signal.connectionId) || []
+    candidates.push({ signal, attempts: 0 })
+    this.pendingCandidates.set(signal.connectionId, candidates)
+
+    debugFn('Queued ICE candidate', signal.connectionId, reason)
+    this.schedulePendingCandidateFlush(signal.connectionId)
+  }
+
+  schedulePendingCandidateFlush(connectionId: bigint) {
+    if (this.pendingCandidateTimers.has(connectionId)) return
+
+    const timer = setTimeout(() => {
+      this.pendingCandidateTimers.delete(connectionId)
+      this.flushPendingCandidates(connectionId)
+    }, PENDING_CANDIDATE_RETRY_MS)
+    timer.unref?.()
+
+    this.pendingCandidateTimers.set(connectionId, timer)
+  }
+
+  flushPendingCandidates(connectionId: bigint) {
+    const candidates = this.pendingCandidates.get(connectionId)
+    if (!candidates?.length) return
+
+    const conn = this.connections.get(connectionId)
+    const remaining: PendingCandidate[] = []
+
+    for (const candidate of candidates) {
+      if (!conn || !this.remoteDescriptionReady.has(connectionId)) {
+        this.requeueCandidate(candidate, remaining, 'connection is not ready')
+        continue
+      }
+
+      try {
+        conn.rtcConnection.addRemoteCandidate(candidate.signal.data, '0')
+      }
+      catch (error) {
+        this.requeueCandidate(candidate, remaining, formatCandidateError(error))
+      }
+    }
+
+    if (remaining.length) {
+      this.pendingCandidates.set(connectionId, remaining)
+      this.schedulePendingCandidateFlush(connectionId)
+    }
+    else {
+      this.pendingCandidates.delete(connectionId)
+    }
+  }
+
+  requeueCandidate(candidate: PendingCandidate, remaining: PendingCandidate[], reason: string) {
+    if (candidate.attempts >= MAX_PENDING_CANDIDATE_ATTEMPTS) {
+      debugFn('Dropping ICE candidate after retries', candidate.signal.connectionId, reason)
+      return
+    }
+
+    remaining.push({
+      signal: candidate.signal,
+      attempts: candidate.attempts + 1,
+    })
   }
 
   async handleOffer(signal: SignalStructure) {
@@ -84,10 +171,16 @@ export class Server {
 
     rtcConnection.onIceStateChange(state => {
       if (state === 'connected') this.onOpenConnection(connection)
-      if (state === 'disconnected') this.onCloseConnection(signal.connectionId, 'disconnected')
+      if (state === 'disconnected') {
+        this.remoteDescriptionReady.delete(signal.connectionId)
+        this.pendingCandidates.delete(signal.connectionId)
+        this.onCloseConnection(signal.connectionId, 'disconnected')
+      }
     })
 
     rtcConnection.setRemoteDescription(signal.data, 'offer')
+    this.remoteDescriptionReady.add(signal.connectionId)
+    this.flushPendingCandidates(signal.connectionId)
 
     const answer = rtcConnection.localDescription()
 
@@ -109,10 +202,14 @@ export class Server {
 
       switch (signal.type) {
         case SignalType.ConnectRequest:
-          this.handleOffer(signal)
+          this.handleOffer(signal).catch(error => {
+            debugFn('Failed to handle connect offer', signal, error)
+          })
           break
         case SignalType.CandidateAdd:
-          this.handleCandidate(signal)
+          this.handleCandidate(signal).catch(error => {
+            debugFn('Failed to handle ICE candidate', signal, error)
+          })
           break
         default:
           debugFn('Received signal for unknown type', signal)
@@ -122,9 +219,20 @@ export class Server {
   }
 
   close() {
+    for (const timer of this.pendingCandidateTimers.values()) {
+      clearTimeout(timer)
+    }
+    this.pendingCandidateTimers.clear()
+    this.pendingCandidates.clear()
+    this.remoteDescriptionReady.clear()
+
     for (const conn of this.connections.values()) {
       conn.close()
     }
   }
 
+}
+
+function formatCandidateError(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -2,6 +2,7 @@ import { CompressionAlgorithm } from './transforms/framer'
 
 export type Options = {
   version: string
+  signalingMode: 'rpc' | 'legacy'
   autoInitPlayer: boolean
   offline: boolean
   connectTimeout: number
@@ -12,11 +13,12 @@ export type Options = {
 }
 
 // Currently supported verson. Note, clients with newer versions can still connect as long as data is in minecraft-data
-export const CURRENT_VERSION = '1.26.10'
+export const CURRENT_VERSION = '1.26.20'
 
-export const defaultOptions = {
+export const defaultOptions: Options = {
   // https://minecraft.wiki/w/Protocol_version#Bedrock_Edition_2
   version: CURRENT_VERSION,
+  signalingMode: 'rpc',
   // client: If we should send SetPlayerInitialized to the server after getting play_status spawn.
   // if this is disabled, no 'spawn' event will be emitted, you should manually set
   // client.status to ClientStatus.Initialized after sending the init packet.
@@ -32,5 +34,5 @@ export const defaultOptions = {
   // server: If true, only compress if a payload is larger than compressionThreshold
   compressionThreshold: 512,
   // server and client: The protocol version to use
-  protocolVersion: 944,
+  protocolVersion: 975,
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -127,7 +127,7 @@ export class Server extends TypedEmitter<ServerEvents> {
 
   async listen(auth: Authflow, networkId: bigint) {
 
-    this.signaling = new Signal(auth, networkId, this.options.version)
+    this.signaling = new Signal(auth, networkId, this.options.version, this.options.signalingMode)
 
     this.nethernet = new NethernetServer(this.signaling, networkId)
 

--- a/src/serverPlayer.ts
+++ b/src/serverPlayer.ts
@@ -6,7 +6,7 @@ import LoginVerify from './handshake/loginVerify'
 import { Connection } from './nethernet/connection'
 import { KeyExchange } from './handshake/keyExchange'
 import { serialize, isDebug } from './datatypes/util'
-import { CURRENT_VERSION, Options } from './options'
+import { Options } from './options'
 import { CompressionAlgorithm, Framer } from './transforms/framer'
 
 const debug = require('debug')('bedrock-portal-nethernet')
@@ -168,7 +168,7 @@ export class Player extends TypedEmitter<PlayerEvents> {
     //     return false
     //   }
     // }
-    if (clientVersion < Number(CURRENT_VERSION)) {
+    if (clientVersion < this.server.options.protocolVersion) {
       this.sendDisconnectStatus('failed_client') // client too old
       return false
     }

--- a/src/signaling/signal.ts
+++ b/src/signaling/signal.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import type { Authflow } from 'prismarine-auth'
 
 import debugFn from 'debug'
@@ -5,7 +6,16 @@ import { stringify } from 'json-bigint'
 import { once, EventEmitter } from 'events'
 import { Data, ErrorEvent, WebSocket } from 'ws'
 
-import { SignalStructure } from './struct'
+import { NetworkId, SignalStructure } from './struct'
+
+type TurnServer = { hostname: string, port: number, username?: string, password?: string }
+type JsonObject = Record<string, unknown>
+
+type PendingRequest = {
+  resolve: (value: unknown) => void
+  reject: (reason?: unknown) => void
+  timer: NodeJS.Timeout
+}
 
 const MessageType = {
   RequestPing: 0,
@@ -13,15 +23,29 @@ const MessageType = {
   Credentials: 2,
 }
 
+const Rpc = {
+  TurnAuth: 'Signaling_TurnAuth_v1_0',
+  SendMessage: 'Signaling_SendClientMessage_v1_0',
+  ReceiveMessage: 'Signaling_ReceiveMessage_v1_0',
+  Ping: 'System_Ping_v1_0',
+  Pong: 'System_Pong_v1_0',
+  WebRtc: 'Signaling_WebRtc_v1_0',
+  Delivery: 'Signaling_DeliveryNotification_V1_0',
+}
+
+const RPC_SIGNAL_URL = 'wss://signal.franchise.minecraft-services.net/ws/v1.0/messaging/connect'
+const LEGACY_SIGNAL_URL = 'wss://signal.franchise.minecraft-services.net/ws/v1.0/signaling'
+const SIGNALING_USER_AGENT = 'libHttpClient/1.0.0.0'
+
 const debug = debugFn('bedrock-portal-nethernet')
 
 export class Signal extends EventEmitter {
 
   public ws: WebSocket | null
 
-  public networkId: bigint
+  public networkId: NetworkId
 
-  public credentials: { hostname: string, port: number, username: string, password: string }[] | null
+  public credentials: TurnServer[] | null
 
   private authflow: Authflow
 
@@ -31,7 +55,11 @@ export class Signal extends EventEmitter {
 
   private retryCount: number
 
-  constructor(authflow: Authflow, networkId: bigint, version: string) {
+  private pendingRequests: Map<string, PendingRequest>
+
+  private mode: 'rpc' | 'legacy'
+
+  constructor(authflow: Authflow, networkId: NetworkId, version: string, signalingMode: 'rpc' | 'legacy' = 'rpc') {
     super()
 
     this.authflow = authflow
@@ -48,6 +76,10 @@ export class Signal extends EventEmitter {
 
     this.retryCount = 0
 
+    this.pendingRequests = new Map()
+
+    this.mode = signalingMode
+
   }
 
   async connect() {
@@ -61,31 +93,22 @@ export class Signal extends EventEmitter {
 
     debug('Disconnecting from Signal')
 
-    if (this.pingInterval) {
-      clearInterval(this.pingInterval)
-      this.pingInterval = null
-    }
+    this.clearPing()
+    this.rejectPending(new Error('Signal disconnected'))
 
     if (this.ws) {
 
       this.ws.onmessage = null
       this.ws.onclose = null
 
-      const shouldClose = this.ws.readyState === WebSocket.OPEN
+      const shouldClose = this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING
 
       if (shouldClose) {
 
-        let outerResolve: any
-
-        const promise = new Promise((resolve) => {
-          outerResolve = resolve
+        await new Promise((resolve) => {
+          this.ws!.onclose = resolve
+          this.ws!.close(1000, 'Normal Closure')
         })
-
-        this.ws.onclose = outerResolve
-
-        this.ws.close(1000, 'Normal Closure')
-
-        await promise
 
       }
 
@@ -105,25 +128,30 @@ export class Signal extends EventEmitter {
 
     debug('Fetched XBL Token', xbl)
 
-    const address = `wss://signal.franchise.minecraft-services.net/ws/v1.0/signaling/${this.networkId}`
+    this.mode = this.mode === 'legacy' ? 'legacy' : 'rpc'
+    const address = this.mode === 'legacy' ? `${LEGACY_SIGNAL_URL}/${this.networkId}` : RPC_SIGNAL_URL
 
     debug('Connecting to Signal', address)
 
-    const ws = new WebSocket(address, {
-      headers: { Authorization: xbl.mcToken },
-    })
-
-    this.pingInterval = setInterval(() => {
-      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-        this.ws.send(JSON.stringify({ Type: MessageType.RequestPing }))
+    const headers = this.mode === 'legacy'
+      ? { Authorization: xbl.mcToken }
+      : {
+        'Authorization': xbl.mcToken,
+        'User-Agent': SIGNALING_USER_AGENT,
+        'session-id': randomUUID(),
+        'request-id': randomUUID(),
       }
-    }, 5000)
+
+    const ws = new WebSocket(address, { headers })
 
     ws.onopen = () => {
       this.onOpen()
+      if (this.mode === 'legacy') this.startLegacyPing()
+      else this.onRpcOpen()
     }
 
     ws.onclose = (event) => {
+      this.handleCloseCleanup(event.code, event.reason)
       this.onClose(event.code, event.reason)
     }
 
@@ -164,18 +192,89 @@ export class Signal extends EventEmitter {
     }
   }
 
+  handleCloseCleanup(code: number, reason: string) {
+    this.clearPing()
+    this.rejectPending(new Error(`Signal closed with code ${code}: ${reason || 'none'}`))
+  }
+
+  clearPing() {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval)
+      this.pingInterval = null
+    }
+  }
+
+  rejectPending(error: Error) {
+    for (const pending of this.pendingRequests.values()) {
+      clearTimeout(pending.timer)
+      pending.reject(error)
+    }
+    this.pendingRequests.clear()
+  }
+
+  startLegacyPing() {
+    this.clearPing()
+    this.pingInterval = setInterval(() => {
+      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ Type: MessageType.RequestPing }))
+      }
+    }, 5000)
+    this.pingInterval.unref?.()
+  }
+
+  onRpcOpen() {
+    this.clearPing()
+    this.pingInterval = setInterval(() => {
+      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+        this.sendJsonRpcRequest(Rpc.Ping, {}).catch(error => {
+          debug('RPC ping failed', error)
+        })
+      }
+    }, 50000)
+    this.pingInterval.unref?.()
+
+    this.sendJsonRpcRequest(Rpc.TurnAuth, {})
+      .then((response) => {
+        this.credentials = parseTurnServers(response)
+        this.emit('credentials', this.credentials)
+      })
+      .catch((error) => {
+        debug('Failed to fetch JSON-RPC TURN credentials', error)
+        if (this.listenerCount('error') > 0) this.emit('error', error)
+      })
+  }
+
   onMessage(res: Data) {
 
+    if (Buffer.isBuffer(res)) res = res.toString('utf8')
     if (!(typeof res === 'string')) return debug('Recieved non-string message', res)
 
-    const message = JSON.parse(res)
+    let message: unknown
+    try {
+      message = JSON.parse(res)
+    }
+    catch (error) {
+      debug('Failed to parse signaling message', res, error)
+      return
+    }
 
     debug('Recieved message', message)
 
+    if (isRecord(message) && 'Type' in message) {
+      return this.onLegacyMessage(message)
+    }
+
+    if (isRecord(message)) {
+      return this.onRpcMessage(message)
+    }
+  }
+
+  onLegacyMessage(message: JsonObject) {
     switch (message.Type) {
       case MessageType.Credentials: {
 
-        if (message.From != 'Server') {
+        const from = getFirstString(message, ['From'])
+        if (from != 'Server') {
           debug('received credentials from non-Server', 'message', message)
           return
         }
@@ -187,7 +286,11 @@ export class Signal extends EventEmitter {
         break
       }
       case MessageType.Signal: {
-        const signal = SignalStructure.fromString(message.Message, BigInt(message.From))
+        const from = getFirstString(message, ['From'])
+        const payload = getFirstString(message, ['Message'])
+        if (!from || !payload) return
+
+        const signal = SignalStructure.fromString(payload, parseNetworkId(from))
 
         this.emit('signal', signal)
         break
@@ -196,11 +299,177 @@ export class Signal extends EventEmitter {
         debug('Signal Pinged')
       }
     }
+  }
 
+  onRpcMessage(message: JsonObject) {
+    if (Object.prototype.hasOwnProperty.call(message, 'result') || (message.error && Object.prototype.hasOwnProperty.call(message, 'id'))) {
+      this.handleRpcResponse(message)
+    }
+    else if (message.method) {
+      this.handleRpcRequest(message)
+    }
+  }
+
+  handleRpcResponse(message: JsonObject) {
+    if (message.id === undefined || message.id === null) return
+
+    const id = String(message.id)
+    const pending = this.pendingRequests.get(id)
+    if (!pending) return
+
+    clearTimeout(pending.timer)
+    this.pendingRequests.delete(id)
+
+    if (message.error) {
+      const rpcError = isRecord(message.error) ? message.error : null
+      const errorMessage = typeof rpcError?.message === 'string' ? rpcError.message : JSON.stringify(message.error)
+      pending.reject(new Error(errorMessage))
+      return
+    }
+
+    pending.resolve(message.result || {})
+  }
+
+  handleRpcRequest(message: JsonObject) {
+    const id = message.id
+    const hasResponseId = typeof id === 'string' || typeof id === 'number'
+
+    switch (typeof message.method === 'string' ? message.method : undefined) {
+      case Rpc.ReceiveMessage: {
+        if (hasResponseId) this.sendJsonRpcResult(id, null)
+
+        const params = Array.isArray(message.params) ? message.params : []
+        for (const item of params) {
+          this.processIncomingRpcMessage(item)
+        }
+        break
+      }
+      case Rpc.Ping:
+      case Rpc.Pong: {
+        if (hasResponseId) this.sendJsonRpcResult(id, null)
+        break
+      }
+      default:
+        debug('Unhandled RPC signaling method', message.method, message)
+    }
+  }
+
+  processIncomingRpcMessage(message: JsonObject) {
+    const from = getFirstString(message, ['From', 'from'])
+    const rawInner = getFirstString(message, ['Message', 'message'])
+    const messageId = getFirstString(message, ['Id', 'id']) || randomUUID()
+
+    if (!from || !rawInner) {
+      debug('Ignoring malformed RPC signal message', message)
+      return
+    }
+
+    this.sendRpcDeliveryAck(from, messageId).catch(error => {
+      debug('Failed to send RPC delivery acknowledgement', error)
+    })
+
+    let inner: unknown
+    try {
+      inner = JSON.parse(rawInner)
+    }
+    catch (error) {
+      debug('Failed to parse inner RPC signaling message', rawInner, error)
+      return
+    }
+
+    if (!isRecord(inner) || inner.method !== Rpc.WebRtc) {
+      debug('Ignoring non-WebRTC RPC inner message', isRecord(inner) ? inner.method : undefined)
+      return
+    }
+
+    const params = isRecord(inner.params) ? inner.params : null
+    const payload = params?.message
+    if (typeof payload !== 'string') {
+      debug('Ignoring RPC WebRTC message without string payload', inner)
+      return
+    }
+
+    const signal = SignalStructure.fromString(payload, parseNetworkId(from))
+    signal.rpcFrom = from
+    this.emit('signal', signal)
+  }
+
+  sendRpcDeliveryAck(target: string, messageId: string) {
+    const innerMessage = {
+      params: { messageId },
+      jsonrpc: '2.0',
+      method: Rpc.Delivery,
+    }
+
+    return this.sendJsonRpcRequest(Rpc.SendMessage, {
+      toPlayerId: String(target),
+      messageId: randomUUID(),
+      message: JSON.stringify(innerMessage),
+    })
+  }
+
+  sendJsonRpcRequest(method: string, params: unknown) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error('WebSocket not connected'))
+    }
+
+    const id = randomUUID()
+    const request = {
+      params,
+      jsonrpc: '2.0',
+      method,
+      id,
+    }
+
+    const promise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(id)
+        reject(new Error(`Timed out waiting for RPC response to ${method}`))
+      }, 30000)
+      timer.unref?.()
+
+      this.pendingRequests.set(id, { resolve, reject, timer })
+    })
+
+    this.ws.send(JSON.stringify(request))
+
+    return promise
+  }
+
+  sendJsonRpcResult(id: string | number, result: unknown) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return
+
+    this.ws.send(JSON.stringify({
+      id,
+      result,
+      jsonrpc: '2.0',
+    }))
   }
 
   write(signal: SignalStructure) {
     if (!this.ws) throw new Error('WebSocket not connected')
+
+    if (this.mode === 'rpc') {
+      const target = signal.rpcFrom || stringifyNetworkId(signal.networkId)
+      const innerMessage = {
+        params: {
+          netherNetId: stringifyNetworkId(this.networkId),
+          message: signal.toString(),
+        },
+        jsonrpc: '2.0',
+        method: Rpc.WebRtc,
+      }
+
+      this.sendJsonRpcRequest(Rpc.SendMessage, {
+        toPlayerId: String(target),
+        messageId: randomUUID(),
+        message: JSON.stringify(innerMessage),
+      }).catch(error => {
+        debug('Failed to send JSON-RPC signal', target, error)
+      })
+      return
+    }
+
     const message = stringify({ Type: MessageType.Signal, To: signal.networkId, Message: signal.toString() })
 
     debug('Sending Signal', message)
@@ -210,24 +479,65 @@ export class Signal extends EventEmitter {
 
 }
 
-function parseTurnServers(dataString: string) {
-  const servers: { hostname: string, port: number, username: string, password: string }[] = []
+function parseNetworkId(value: unknown): NetworkId {
+  if (typeof value === 'bigint') return value
 
-  const data = JSON.parse(dataString)
+  const stringValue = String(value)
+  if (/^[0-9]+$/.test(stringValue)) {
+    try {
+      return BigInt(stringValue)
+    }
+    catch (_error) {
+      return stringValue
+    }
+  }
 
-  if (!data.TurnAuthServers) return servers
+  return stringValue
+}
 
-  for (const server of data.TurnAuthServers) {
-    if (!server.Urls) continue
+function stringifyNetworkId(value: NetworkId) {
+  return typeof value === 'bigint' ? value.toString() : String(value)
+}
 
-    for (const url of server.Urls) {
-      const match = url.match(/(stun|turn):([^:]+):(\d+)/)
+function isRecord(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === 'object'
+}
+
+function getFirstString(source: unknown, keys: string[]) {
+  if (!isRecord(source)) return undefined
+
+  for (const key of keys) {
+    const value = source[key]
+    if (value !== undefined && value !== null) return String(value)
+  }
+
+  return undefined
+}
+
+function parseTurnServers(dataString: string | unknown) {
+  const servers: TurnServer[] = []
+
+  const data = typeof dataString === 'string' ? JSON.parse(dataString) : dataString
+
+  if (!isRecord(data)) return servers
+
+  const turnServers = data.TurnAuthServers || data.turnAuthServers
+  if (!Array.isArray(turnServers)) return servers
+
+  for (const server of turnServers) {
+    if (!isRecord(server)) continue
+
+    const urls = server.Urls || server.urls
+    if (!Array.isArray(urls)) continue
+
+    for (const url of urls) {
+      const match = String(url).match(/^(stun|turn):(?:\[([^\]]+)\]|([^:/?]+)):(\d+)/)
       if (match) {
         servers.push({
-          hostname: match[2],
-          port: parseInt(match[3], 10),
-          username: server.Username || undefined,
-          password: server.Password || undefined,
+          hostname: match[2] || match[3],
+          port: parseInt(match[4], 10),
+          username: getFirstString(server, ['Username', 'username']),
+          password: getFirstString(server, ['Password', 'password', 'Credential', 'credential']),
         })
       }
     }

--- a/src/signaling/struct.ts
+++ b/src/signaling/struct.ts
@@ -1,3 +1,5 @@
+export type NetworkId = bigint | string
+
 export const SignalType = {
   ConnectRequest: 'CONNECTREQUEST',
   ConnectResponse: 'CONNECTRESPONSE',
@@ -13,9 +15,11 @@ export class SignalStructure {
 
   data: string
 
-  networkId: bigint
+  networkId: NetworkId
 
-  constructor(type: string, connectionId: bigint, data: string, networkId: bigint) {
+  rpcFrom?: string
+
+  constructor(type: string, connectionId: bigint, data: string, networkId: NetworkId) {
     this.type = type
     this.connectionId = connectionId
     this.data = data
@@ -26,7 +30,7 @@ export class SignalStructure {
     return `${this.type} ${this.connectionId} ${this.data}`
   }
 
-  static fromString(message: string, networkId: bigint) {
+  static fromString(message: string, networkId: NetworkId) {
     const [type, connectionId, ...data] = message.split(' ')
 
     return new this(type, BigInt(connectionId), data.join(' '), networkId)


### PR DESCRIPTION
## Summary
- default NetherNet to Bedrock 1.26.20 / protocol 975
- add JSON-RPC signaling support with a legacy signaling mode option
- preserve pending JSON-RPC requests and parse TURN credentials from both legacy and RPC responses
- queue ICE candidates until the connection and remote description are ready
- validate client protocol versions against protocolVersion instead of Number(CURRENT_VERSION)

## Validation
- npm run build
- npm run lint (passes with existing no-explicit-any warnings)